### PR TITLE
Add dynamic distance tooltip whilst drawing

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -6,10 +6,10 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js" integrity="sha512-uto9mlQzrs59VwILcLiRYeLKPPbS/bT71da/OEBYEwcdNUk8jYIy+D176RYoop1Da+f9mvkYrmj5MCLZWEtQuA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui-touch-punch/0.2.3/jquery.ui.touch-punch.min.js" integrity="sha512-0bEtK0USNd96MnO4XhH8jhv3nyRF0eK87pJke6pkYf3cM0uDIhNJy9ltuzqgypoIFXw3JSuiy04tVk4AjpZdZw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.3/leaflet.js" integrity="sha512-Dqm3h1Y4qiHUjbhxTuBGQsza0Tfppn53SHlu/uj1f+RT+xfShfe7r6czRf5r2NmllO2aKx+tYJgoxboOkn1Scg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.js" integrity="sha512-BwHfrr4c9kmRkLw6iXFdzcdWV/PGkVgiIyIWLLlTSXzWQzxuSg4DiQUCpauz/EWjgk5TYQqX/kvn9pG1NpYfqg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet-minimap/3.6.1/Control.MiniMap.min.js" integrity="sha512-WL3nAJlWFKoDShduxQRyY3wkBnQsINXdIfWIW48ZaPgYz1wYNnxIwFMMgigzSgjNBC2WWZ8Y8/sSyUU6abuF0g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@geoman-io/leaflet-geoman-free@2.11.2/dist/leaflet-geoman.min.js" integrity="sha256-QQvd7B0d0uE9O1xmZFmfRn5eGS2rLICX8sor3SSQdZo=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-	<script src="./js/leaflet.tilelayer.fallback.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@geoman-io/leaflet-geoman-free@2.17.0/dist/leaflet-geoman.min.js" integrity="sha256-pX70+HFTovwMt6Er9D4aTigqATNq8Cz/bY8Zj3DH66g=" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="./js/leaflet.tilelayer.fallback.js"></script>
   <script src="./js/FileSaver.min.js"></script>
   <script src="./js/toGeoJSON.js"></script>
   <script src="./js/tokml.js"></script>
@@ -25,9 +25,9 @@
   <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.css" integrity="sha512-aOG0c6nPNzGk+5zjwyJaoRUgCdOrfSDhmMID2u4+OIslr0GjpLKo7Xm0Ao3xmpM4T8AmIouRkqwj1nrdVsLKEQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/leaflet.min.css" integrity="sha512-1xoFisiGdy9nvho8EgXuXvnpR5GAMSjFwp40gSRE3NwdUdIMIKuPa7bqoUhLD0O/5tPNhteAsE5XyyMi5reQVA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-	<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" />
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet-minimap/3.6.1/Control.MiniMap.min.css" integrity="sha512-qm+jY0iQ4Xf5RL79UB75REDLYD0jtvxxVZp2RVIW8sm8RNiHdeN43oksqUPrBIshJtQcVPrAL08ML2Db8fFZiA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@geoman-io/leaflet-geoman-free@2.11.2/dist/leaflet-geoman.css" integrity="sha256-zU1LEqhSSViGZpUWjI0cPrit5ux5qD8AzHuFJwjHorA=" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@geoman-io/leaflet-geoman-free@2.17.0/dist/leaflet-geoman.min.css" integrity="sha256-1WJw0dMpNDzZ/puFDJoSN/PmSwR8iHcFr2wNB2yz2Yk=" crossorigin="anonymous">
   <link rel="stylesheet" href="./js/leaflet.draw/leaflet.draw.css" />
   <link rel="stylesheet" href="./js/opacity/Control.Opacity.css" />
   <link rel="stylesheet" href="./css/leaflet.mouseCoordinateNSW.css" />

--- a/js/map.js
+++ b/js/map.js
@@ -181,6 +181,25 @@ map.on('pm:create', function(e) {
   drawnItems.addLayer(e.layer);
 });
 
+map.on("pm:drawstart", ({ workingLayer }) => {
+  workingLayer.on("pm:change", (e) => {
+    if (e.shape === 'Line' && e.latlngs.length>1 ) {
+      total = 'Total = ' + L.GeometryUtil.getDistance(e.latlngs).toFixed(2) + ' km';
+      workingLayer.bindTooltip(
+        total,
+        {
+          offset: L.point(-10, -10),
+          opacity: 0.75
+        }
+      ).openTooltip();
+    }
+    else if (e.shape === 'Polygon' || e.shape === 'Rectangle') {
+      measure = ((L.GeometryUtil.geodesicArea(e.latlngs[0]) / 1000000).toFixed(2) + ' km<sup>2</sup>');
+      workingLayer.bindTooltip(measure,{}).openTooltip();
+    }
+  });
+});
+
 //-----------------
 // Leaflet.Save 
 // Save to KML requires tokml.js, Save to GPX requires togpx.js
@@ -406,7 +425,7 @@ function onEachFeature(feature, layer) {
   layer.on('pm:remove', function(e) {
     drawnItems.removeLayer(e.layer);
   });
-  
+
   drawnItems.addLayer(layer); //dodgy adding to global?
 }
 


### PR DESCRIPTION
Added a tooltip that shows a running measurement (distance, or area) during drawing. We already display this once drawing is completed, but it's useful to also see it whilst drawing. In the process, also bumped leaflet-geoman-free to 2.17.0 (the latest at time of writing).

In my testing, I found that sometimes the tooltip gets in the way, mainly when drawing smaller segments. I was not able to work out how to move the tooltip out of the way of the cursor in to fix this, so just changed the opacity to make it less of a problem.

EDIT: Refactored to hijack the existing tooltip for Line drawing, so that the text follows the cursor. Used the format from https://geoman.io/docs/options/measurement and used the translations to support internationalisation (even though it's probably not needed here!)